### PR TITLE
Fix generation of trap OID in genTrapType()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysnmp-pysmi"
-version = "1.1.10-beta.2"
+version = "1.1.10"
 description = ""
 authors = ["rfaircloth-splunk <rfaircloth@splunk.com>"]
 license = "BSD-2-Clause"

--- a/pysmi/__init__.py
+++ b/pysmi/__init__.py
@@ -1,2 +1,2 @@
 # http://www.python.org/dev/peps/pep-0396/
-__version__ = "1.1.10-beta.2"
+__version__ = "1.1.10"

--- a/pysmi/codegen/jsondoc.py
+++ b/pysmi/codegen/jsondoc.py
@@ -493,7 +493,7 @@ class JsonCodeGen(AbstractCodeGen):
 
         outDict = OrderedDict()
         outDict['name'] = name
-        outDict['oid'] = enterpriseStr + '0.' + str(value)
+        outDict['oid'] = enterpriseStr + '.0.' + str(value)
         outDict['class'] = 'notificationtype'
 
         if variables:


### PR DESCRIPTION
Adds a missing "." in front of the "0" when creating the trap OID (e.g. the correct "1.3.6.1.4.1.111.15.2.0.1" instead of "1.3.6.1.4.1.111.15.20.1" for Oracle Enterprise Manager's "oraEM4Alert"). This was actually fixed in PySMI's original repository for version 0.4.0 (see https://github.com/etingof/pysmi/blob/58f2bf29cccff633af703f319dc237e17e16e3d3/pysmi/codegen/intermediate.py#L497), where the code in question was also moved to a different file (intermediate.py).