### PR TITLE
fix: parsing path for windows

### DIFF
--- a/pysmi/reader/url.py
+++ b/pysmi/reader/url.py
@@ -7,6 +7,7 @@
 import sys
 
 from urllib import parse as urlparse
+from urllib.request import url2pathname
 from pysmi.reader.localfile import FileReader
 from pysmi.reader.zipreader import ZipReader
 from pysmi.reader.httpclient import HttpReader
@@ -28,9 +29,9 @@ def getReadersFromUrls(*sourceUrls, **options):
                 scheme = 'file'
 
             if scheme == 'file':
-                readers.append(FileReader(mibSource.path).setOptions(**options))
+                readers.append(FileReader(url2pathname(mibSource.path)).setOptions(**options))
             else:
-                readers.append(ZipReader(mibSource.path).setOptions(**options))
+                readers.append(ZipReader(url2pathname(mibSource.path)).setOptions(**options))
 
         elif mibSource.scheme in ('http', 'https'):
             readers.append(HttpReader(sourceUrl).setOptions(**options))


### PR DESCRIPTION
Hi, We encountered this error on windows:

```
pysmi: current MIB source(s): FileReader{"\C:\Users\myUser\Downloads\traps"},
```

When using `getReadersFromUrls` with an url that in this format `file:///C:/Users/myUser/Downloads/traps`.

After investigation, it looks similar to this issue:

https://stackoverflow.com/questions/43911052/urlparse-on-a-windows-file-scheme-uri-leaves-extra-slash-at-start

As suggested in the link above, using `url2pathname()` can help fix the issue.